### PR TITLE
Remove __version__ attribute

### DIFF
--- a/monkeybiz/__init__.py
+++ b/monkeybiz/__init__.py
@@ -1,16 +1,9 @@
 import functools
 import inspect
-import pkg_resources
 from types import ModuleType
 
 import six
 from six.moves import filter
-
-
-try:
-    __version__ = pkg_resources.get_distribution('python-monkey-business').version
-except pkg_resources.DistributionNotFound:
-    __version__ = None
 
 
 def patch(func=None, obj=None, name=None, avoid_doublewrap=True):


### PR DESCRIPTION
`pkg_resources` has been removed in Python 3.12, breaking this pattern. I recommend not providing a `__version__` attribute since it’s not a standard and can be replaced with `importlib.metadata.version()`. I dropped the version attributes in my packages years ago and no one complained.